### PR TITLE
null join key data skew optimization (aka salty nulls)

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -212,7 +212,8 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             minRetentionTime,
                             isBatchBackfillEnabled,
                             isMinibatchEnabled,
-                            maxMinibatchSize);
+                            maxMinibatchSize,
+                            joinSpec.getNonEquiCondition().isEmpty());
 
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinSaltNullsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinSaltNullsRule.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.api.TableException;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinInfo;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.rules.FilterMultiJoinMergeRule;
+import org.apache.calcite.rel.rules.MultiJoin;
+import org.apache.calcite.rel.rules.ProjectMultiJoinMergeRule;
+import org.apache.calcite.rel.rules.TransformationRule;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.rex.RexVisitor;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.fun.SqlRandIntegerFunction;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.Pair;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWatermarkAssigner;
+
+
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+/**
+ */
+public class FlinkJoinSaltNullsRule extends RelRule<FlinkJoinSaltNullsRule.Config>
+        implements TransformationRule {
+    private static final Logger LOG = LoggerFactory.getLogger(FlinkJoinSaltNullsRule.class);
+
+    public static final FlinkJoinSaltNullsRule INSTANCE =
+            FlinkJoinSaltNullsRule.Config.DEFAULT.toRule();
+
+    /** Creates a JoinToMultiJoinRule. */
+    public FlinkJoinSaltNullsRule(Config config) {
+        super(config);
+    }
+
+    @Deprecated // to be removed before 2.0
+    public FlinkJoinSaltNullsRule(Class<? extends Join> clazz) {
+        this(Config.DEFAULT.withOperandFor(clazz));
+    }
+
+    @Deprecated // to be removed before 2.0
+    public FlinkJoinSaltNullsRule(
+            Class<? extends Join> joinClass, RelBuilderFactory relBuilderFactory) {
+        this(
+                Config.DEFAULT
+                        .withRelBuilderFactory(relBuilderFactory)
+                        .as(Config.class)
+                        .withOperandFor(joinClass));
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        final Join join = call.rel(0);
+        final JoinInfo joinInfo = join.analyzeCondition();
+
+        if (join.getJoinType() == JoinRelType.LEFT && joinInfo.isEqui()) {
+            // Look for left joins with an equijoin condition
+            return true;
+        }
+        return false;
+    }
+
+    private LogicalProject getSourceProject(RelNode node) {
+        LOG.info("SERGEI here {}", node);
+        for (RelNode n : node.getInputs()) {
+            if (n instanceof HepRelVertex) {
+                n = ((HepRelVertex)n).getCurrentRel();
+            }
+            if (n instanceof LogicalProject) {
+                return (LogicalProject)n;
+            }
+            return getSourceProject(n);
+        }
+        return null;
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        final Join origJoin = call.rel(0);
+        final RelNode origLeft = call.rel(1);
+        final RelNode origRight = call.rel(2);
+        final RelBuilder relBuilder = call.builder();
+        final RexBuilder rexBuilder = origJoin.getCluster().getRexBuilder();
+        final RelDataType intType = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER);
+
+
+        List<String> leftFieldNames = new ArrayList<>(origLeft.getRowType().getFieldNames());
+        leftFieldNames.add("__rubisalt_left");
+
+        RexNode leftSaltExpr = relBuilder.call(new SqlRandIntegerFunction(), relBuilder.push(origLeft).field(0));
+
+        RelNode leftSaltedProject = 
+            relBuilder
+                .push(origLeft)
+                .project(Iterables.concat(relBuilder.fields(), ImmutableList.of(leftSaltExpr)), leftFieldNames, true)
+                .build();
+
+        LOG.info("SERGEI leftSaltedProject {}", leftSaltedProject);
+
+
+        List<String> rightFieldNames = new ArrayList<>(origRight.getRowType().getFieldNames());
+        rightFieldNames.add("__rubisalt_right");
+
+        RexNode rightSaltExpr = relBuilder.call(new SqlRandIntegerFunction(), relBuilder.push(origRight).field(0));
+
+        RelNode rightSaltedProject = 
+            relBuilder
+                .push(origRight)
+                .project(Iterables.concat(relBuilder.fields(), ImmutableList.of(rightSaltExpr)), rightFieldNames, true)
+                .build();
+
+        RexNode origJoinCondition = origJoin.getCondition();
+
+        LOG.info("SERGEI rightSaltedProject {}", rightSaltedProject);
+
+        RexNode saltyJoinCondition =
+            relBuilder
+                .push(leftSaltedProject)
+                .push(rightSaltedProject)
+                .and(origJoinCondition, relBuilder.equals(relBuilder.field(1), relBuilder.field(2)));
+
+        final Join saltyJoin = origJoin.copy(
+            origJoin.getTraitSet(),
+            saltyJoinCondition,
+            leftSaltedProject,
+            rightSaltedProject,
+            origJoin.getJoinType(),
+            false);
+
+        LOG.info("SERGEI salted join {} row type {}", saltyJoin, saltyJoin.getRowType());
+
+        final RelNode saltyProject =
+            relBuilder
+                .push(saltyJoin)
+                .projectExcept(relBuilder.fields(ImmutableList.of("__rubisalt_left", "__rubisalt_right")))
+                .build();
+            
+        LOG.info("SERGEI salted project {}", saltyProject);
+
+        // RexNode cond = origJoin.getCondition();
+        // cond.accept(new RexShuttle() {
+        //     public RexNode visitInputRef(RexInputRef node) {
+        //         LOG.info("SERGEI cond visitor innput ref {}", node);
+        //         return node;
+        //     }
+        // });
+
+        call.transformTo(saltyProject);
+        // call.transformTo(saltyJoin);
+    }
+
+    /** Rule configuration. */
+    public interface Config extends RelRule.Config {
+        Config DEFAULT = EMPTY.as(Config.class).withOperandFor(LogicalJoin.class);
+
+        @Override
+        default FlinkJoinSaltNullsRule toRule() {
+            return new FlinkJoinSaltNullsRule(this);
+        }
+
+        /** Defines an operand tree for the given classes. */
+        default Config withOperandFor(Class<? extends Join> joinClass) {
+            return withOperandSupplier(
+                            b0 ->
+                                    b0.operand(joinClass)
+                                            .inputs(
+                                                    b1 -> b1.operand(RelNode.class).anyInputs(),
+                                                    b2 -> b2.operand(RelNode.class).anyInputs()))
+                    .as(Config.class);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinSaltNullsRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkJoinSaltNullsRule.java
@@ -124,7 +124,7 @@ public class FlinkJoinSaltNullsRule extends RelRule<FlinkJoinSaltNullsRule.Confi
                             relBuilder.call(FlinkSqlOperatorTable.RAND_INTEGER, rexBuilder.makeLiteral(128, intType, false)),
                             rexBuilder.makeLiteral(0, intType, false));
 
-        RelNode leftSaltedProject = 
+        RelNode leftSaltedProject =
             relBuilder
                 .push(origLeft)
                 .project(Iterables.concat(relBuilder.fields(), ImmutableList.of(leftSaltExpr)), leftFieldNames, true)
@@ -159,7 +159,7 @@ public class FlinkJoinSaltNullsRule extends RelRule<FlinkJoinSaltNullsRule.Confi
                         }
                 });
 
-        RelNode rightSaltedProject = 
+        RelNode rightSaltedProject =
             relBuilder
                 .push(origRight)
                 .project(Iterables.concat(relBuilder.fields(), ImmutableList.of(rightSaltExpr)), rightFieldNames, true)
@@ -197,7 +197,7 @@ public class FlinkJoinSaltNullsRule extends RelRule<FlinkJoinSaltNullsRule.Confi
                 .push(saltyJoin)
                 .projectExcept(relBuilder.fields(ImmutableList.of(LEFT_SALT_NAME, RIGHT_SALT_NAME)))
                 .build();
-            
+
         call.transformTo(saltyProject);
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -45,22 +45,6 @@ object FlinkStreamProgram {
   def buildProgram(tableConfig: ReadableConfig): FlinkChainedProgram[StreamOptimizeContext] = {
     val chainedProgram = new FlinkChainedProgram[StreamOptimizeContext]()
 
-    // salt left joins
-    chainedProgram.addLast(
-      SALT_JOINS,
-      FlinkGroupProgramBuilder
-        .newBuilder[StreamOptimizeContext]
-        .addProgram(
-          FlinkHepRuleSetProgramBuilder.newBuilder
-            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
-            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
-            .add(FlinkStreamRuleSets.RUBICON_RULES)
-            .build(),
-          "salt left joins to prevent hot nulls data skew"
-        )
-        .build()
-    )
-
     // rewrite sub-queries to joins
     chainedProgram.addLast(
       SUBQUERY_REWRITE,
@@ -246,6 +230,22 @@ object FlinkStreamProgram {
           .build()
       )
     }
+
+    // salt left joins
+    chainedProgram.addLast(
+      SALT_JOINS,
+      FlinkGroupProgramBuilder
+        .newBuilder[StreamOptimizeContext]
+        .addProgram(
+          FlinkHepRuleSetProgramBuilder.newBuilder
+            .setHepRulesExecutionType(HEP_RULES_EXECUTION_TYPE.RULE_SEQUENCE)
+            .setHepMatchOrder(HepMatchOrder.BOTTOM_UP)
+            .add(FlinkStreamRuleSets.RUBICON_RULES)
+            .build(),
+          "salt left joins to prevent hot nulls data skew"
+        )
+        .build()
+    )
 
     // project rewrite
     chainedProgram.addLast(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -220,6 +220,10 @@ object FlinkStreamRuleSets {
     CoreRules.JOIN_TO_MULTI_JOIN
   )
 
+  val RUBICON_RULES: RuleSet = RuleSets.ofList(
+    FlinkJoinSaltNullsRule.INSTANCE
+  )
+
   val JOIN_REORDER_RULES: RuleSet = RuleSets.ofList(
     // equi-join predicates transfer
     RewriteMultiJoinConditionRule.INSTANCE,

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
@@ -73,7 +73,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
     private transient Counter leftInputDroppedNullKeyCount;
     private transient Counter rightInputDroppedNullKeyCount;
 
-    private transient boolean isEquijoin;
+    private boolean isEquijoin;
 
     public StreamingJoinOperator(
             InternalTypeInfo<RowData> leftType,
@@ -87,7 +87,8 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
             long stateRetentionTime,
             boolean isBatchBackfillEnabled,
             boolean isMinibatchEnabled,
-            int maxMinibatchSize) {
+            int maxMinibatchSize,
+            boolean isEquijoin) {
         super(
                 leftType,
                 rightType,
@@ -101,6 +102,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
         this.rightIsOuter = rightIsOuter;
         this.isMinibatchEnabled = isMinibatchEnabled;
         this.maxMinibatchSize = maxMinibatchSize;
+        this.isEquijoin = isEquijoin;
     }
 
     @Override
@@ -117,9 +119,6 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
         this.rightInputNullKeyCount = getRuntimeContext().getMetricGroup().counter("join.rightInputNullKeyCount");
         this.leftInputDroppedNullKeyCount = getRuntimeContext().getMetricGroup().counter("join.leftInputDroppedNullKeyCount");
         this.rightInputDroppedNullKeyCount = getRuntimeContext().getMetricGroup().counter("join.rightInputDroppedNullKeyCount");
-
-        // XXX(sergei): this is a LIE -- we need to check the join condition
-        isEquijoin = true;
 
         // initialize states
         if (leftIsOuter) {


### PR DESCRIPTION
Handle cases where in an outer join, our join keys are NULL, resulting in a hot hash bucket. For some sparse joins, the data skew becomes extreme causing extremely poor performance. 

The optimization works by adding a "salt" to the join key which is a random number if any of the join keys are NULL. 