### PR TITLE
[FENTIK-FLINK-32] Adding telemetry to the code optimization in the changelog normalizer that early aborts in case of no relevant changes

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
 import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.util.Collector;
+import org.apache.flink.metrics.Counter;
 
 import static org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionHelper.processLastRowOnChangelog;
 import static org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionHelper.processLastRowOnProcTime;
@@ -43,6 +44,9 @@ public class ProcTimeDeduplicateKeepLastRowFunction
     /** The record equaliser used to equal RowData. */
     private transient RecordEqualiser equaliser;
 
+    /**  The counter used to track safely dropped changelogs */
+    private transient Counter deduplicateSafeDropChangelogCount;
+
     public ProcTimeDeduplicateKeepLastRowFunction(
             InternalTypeInfo<RowData> typeInfo,
             long stateRetentionTime,
@@ -56,12 +60,14 @@ public class ProcTimeDeduplicateKeepLastRowFunction
         this.inputIsInsertOnly = inputInsertOnly;
         this.genRecordEqualiser = genRecordEqualiser;
         this.isStateTtlEnabled = stateRetentionTime > 0;
+        
     }
 
     @Override
     public void open(Configuration configure) throws Exception {
         super.open(configure);
         equaliser = genRecordEqualiser.newInstance(getRuntimeContext().getUserCodeClassLoader());
+        deduplicateSafeDropChangelogCount = getRuntimeContext().getMetricGroup().counter("deduplicate.safeDropChangelog");
     }
 
     @Override
@@ -78,7 +84,13 @@ public class ProcTimeDeduplicateKeepLastRowFunction
                     equaliser);
         } else {
             processLastRowOnChangelog(
-                    input, generateUpdateBefore, state, out, isStateTtlEnabled, equaliser);
+                input,
+                generateUpdateBefore,
+                state,
+                out,
+                isStateTtlEnabled,
+                equaliser,
+                deduplicateSafeDropChangelogCount);
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/ProcTimeDeduplicateKeepLastRowFunction.java
@@ -60,7 +60,6 @@ public class ProcTimeDeduplicateKeepLastRowFunction
         this.inputIsInsertOnly = inputInsertOnly;
         this.genRecordEqualiser = genRecordEqualiser;
         this.isStateTtlEnabled = stateRetentionTime > 0;
-        
     }
 
     @Override


### PR DESCRIPTION
Issue
-------------------------------------------------- 
https://github.com/fentik/flink/issues/32

Test Plan
-------------------------------------------------- 
Issued the following queries & observed that
deduplicate.safeDropChangelog count is equal to 2

Queries issued (in order)
-------------------------------------------------- 
update product set category_id=124 where id=100003;
update product set category_id=125 where id=100003;
update product set category_id=125 where id=100003;
update product set category_id=124 where id=100003;

Output from Flink SQL (Last 4 rows)
--------------------------------------------------
| +I |        3430 |                    nhSHm dBBTI | Next skin security choose o... |                 3037 |
| +I |        5699 |                    qlAxh icQVj | Treat trouble feel represen... |                 4462 |
| +I |        9402 |                    bDRRz BXTaq | Hope behavior reality marri... |                  226 |
| -U |      100003 |                            abc |                            abc |                  124 |
| +U |      100003 |                            abc |                            abc |                  125 |
| -U |      100003 |                            abc |                            abc |                  125 |
| +U |      100003 |                            abc |                            abc |                  124 |

Output from JMX metrics (See count = 2 which reflects two no-op updates)
-------------------------------------------------- org.apache.flink.taskmanager.job.task.operator.deduplicate.safeDropChangelog:job_id=0011e4225acf759d4eb3cdffc30a516d,job_name=collect,tm_id=10.0.128.23-45629-db5873,task_attempt_id=36728ec223171ee9c904ca88559a4d6b_c27dcf7b54ef6bfd6cff02ca8870b681_0_0,task_attempt_num=0,subtask_index=0,task_id=c27dcf7b54ef6bfd6cff02ca8870b681,operator_name=ChangelogNormalize[13],task_name=ChangelogNormalize[13]_-_ConstraintEnforcer[14]_-_Sink-_Collect_table_sink,operator_id=c27dcf7b54ef6bfd6cff02ca8870b681,host=10.0.128.23/Count: 2

Output in Datadog 
--------------------
<img width="829" alt="Screen Shot 2023-03-14 at 1 56 35 PM" src="https://user-images.githubusercontent.com/8899705/225134439-c5920d22-6c99-4332-a588-2667d574ce67.png">
