### PR TITLE
Add support for stateless join on NULL key

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -374,7 +374,7 @@ public class ExecutionConfigOptions {
 	public static final ConfigOption<Boolean> TABLE_EXEC_STATELESS_JOIN_ON_NULL_KEY =
 			key("table.exec.stateless-join-on-null-key")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription("Use stateless joins on null key");
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -369,6 +369,14 @@ public class ExecutionConfigOptions {
                     .defaultValue(false)
                     .withDescription("Use hybrid batch stream mode for backfill");
 
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+	public static final ConfigOption<Boolean> TABLE_EXEC_STATELESS_JOIN_ON_NULL_KEY =
+			key("table.exec.stateless-join-on-null-key")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Use stateless joins on null key");
+
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Boolean> TABLE_EXEC_IS_BOUNDED_LATEST =
             key("table.exec.force-bounded-latest")

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -358,7 +358,6 @@ public class ExecutionConfigOptions {
                                     + "MiniBatch is an optimization to buffer input records to reduce state access. "
                                     + "MiniBatch is triggered with the allowed latency interval and when the maximum number of buffered records reached. ");
 
-
     // ------------------------------------------------------------------------
     // Backfill Exec Options
     // ------------------------------------------------------------------------
@@ -369,10 +368,9 @@ public class ExecutionConfigOptions {
                     .defaultValue(false)
                     .withDescription("Use hybrid batch stream mode for backfill");
 
-
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
-	public static final ConfigOption<Boolean> TABLE_EXEC_STATELESS_JOIN_ON_NULL_KEY =
-			key("table.exec.stateless-join-on-null-key")
+    public static final ConfigOption<Boolean> TABLE_EXEC_STATELESS_JOIN_ON_NULL_KEY =
+            key("table.exec.stateless-join-on-null-key")
                     .booleanType()
                     .defaultValue(true)
                     .withDescription("Use stateless joins on null key");
@@ -390,7 +388,6 @@ public class ExecutionConfigOptions {
                     .booleanType()
                     .defaultValue(true)
                     .withDescription("Use DedupSinkUpsertMaterializer variant");
-
 
     @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
     public static final ConfigOption<Duration> TABLE_EXEC_MINIBATCH_ALLOW_LATENCY =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -196,6 +196,7 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             maxMinibatchSize);
 
         } else {
+            final boolean statelessNullKeysEnabled = config.get(ExecutionConfigOptions.TABLE_EXEC_STATELESS_JOIN_ON_NULL_KEY);
             boolean leftIsOuter = joinType == FlinkJoinType.LEFT || joinType == FlinkJoinType.FULL;
             boolean rightIsOuter =
                     joinType == FlinkJoinType.RIGHT || joinType == FlinkJoinType.FULL;
@@ -213,7 +214,8 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                             isBatchBackfillEnabled,
                             isMinibatchEnabled,
                             maxMinibatchSize,
-                            joinSpec.getNonEquiCondition().isEmpty());
+                            joinSpec.getNonEquiCondition().isEmpty(),
+                            statelessNullKeysEnabled);
 
         }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
@@ -561,6 +561,7 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
         } else {
             outRow.replace(leftNullRow, row);
         }
+        outRow.setRowKind(row.getRowKind());
         collector.collect(outRow);
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingPerfOptimizationUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingPerfOptimizationUtil.java
@@ -1,0 +1,33 @@
+package org.apache.flink.table.runtime.operators.join.stream;
+
+import org.apache.flink.table.data.RowData;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StreamingPerfOptimizationUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(StreamingPerfOptimizationUtil.class);
+
+    public static boolean isEligibleForNullEquijoinOptimization(
+        boolean isKeyAnyNulls,
+        boolean isEquijoin,
+        boolean isBatchMode,
+        boolean statelessNullKeysEnabled,
+        boolean isOuterJoin
+    ){
+        if (statelessNullKeysEnabled && isEquijoin && !isBatchMode && isOuterJoin && isKeyAnyNulls) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isKeyAnyNulls(RowData key) {
+        for (int i = 0; i < key.getArity(); i++) {
+            if (key.isNullAt(i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
@@ -122,11 +122,11 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
         if (isAntiJoin) {
             // Left Anti Join
             leftRecordStateView.emitAntiJoinState(getKeyedStateBackend(), this.collector,
-                rightRecordStateView, joinCondition, true, true, false, false, statelessNullKeysEnabled, isBatchMode());
+                rightRecordStateView, joinCondition, true, true, false, false, statelessNullKeysEnabled);
         } else {
             // Left Semi Join
             leftRecordStateView.emitCompleteState(getKeyedStateBackend(), this.collector,
-                rightRecordStateView, joinCondition, true, true, false, false, statelessNullKeysEnabled, isBatchMode());
+                rightRecordStateView, joinCondition, true, true, false, false, statelessNullKeysEnabled);
         }
         setStreamMode(true);
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
@@ -51,6 +51,7 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
     // right join state
     private transient JoinRecordStateView rightRecordStateView;
     private transient MiniBatchJoinBuffer rightRecordStateBuffer;
+    private static final boolean statelessNullKeysEnabled = false;
 
     public StreamingSemiAntiJoinOperator(
             boolean isAntiJoin,
@@ -121,11 +122,11 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
         if (isAntiJoin) {
             // Left Anti Join
             leftRecordStateView.emitAntiJoinState(getKeyedStateBackend(), this.collector,
-                rightRecordStateView, joinCondition, true, true);
+                rightRecordStateView, joinCondition, true, true, false, false, statelessNullKeysEnabled, isBatchMode());
         } else {
             // Left Semi Join
             leftRecordStateView.emitCompleteState(getKeyedStateBackend(), this.collector,
-                rightRecordStateView, joinCondition, true, true);
+                rightRecordStateView, joinCondition, true, true, false, false, statelessNullKeysEnabled, isBatchMode());
         }
         setStreamMode(true);
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateView.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateView.java
@@ -46,5 +46,5 @@ public interface JoinRecordStateView {
     /** Emit join state */
     void emitCompleteState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
             JoinRecordStateView otherView, JoinCondition condition, boolean leftRowOnly,
-            boolean inputIsLeft) throws Exception;
+            boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception;
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateView.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateView.java
@@ -46,5 +46,5 @@ public interface JoinRecordStateView {
     /** Emit join state */
     void emitCompleteState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
             JoinRecordStateView otherView, JoinCondition condition, boolean leftRowOnly,
-            boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception;
+            boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled) throws Exception;
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.runtime.generated.JoinCondition;
 import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.table.data.util.RowDataUtil;
+import org.apache.flink.table.runtime.operators.join.stream.StreamingPerfOptimizationUtil;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -133,7 +134,7 @@ public final class JoinRecordStateViews {
         @Override
         public void emitCompleteState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
                 JoinRecordStateView otherView, JoinCondition condition, boolean leftRowOnly,
-                boolean inputIsLeft) throws Exception {
+                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception {
             emitCompleteState(be, collect, otherView, condition);
         }
 
@@ -220,7 +221,7 @@ public final class JoinRecordStateViews {
         @Override
         public void emitCompleteState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
                 JoinRecordStateView otherView, JoinCondition condition, boolean leftRowOnly,
-                boolean inputIsLeft) throws Exception {
+                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception {
             emitCompleteState(be, collect, otherView, condition);
         }
 
@@ -340,7 +341,7 @@ public final class JoinRecordStateViews {
         @Override
         public void emitCompleteState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
                 JoinRecordStateView otherView, JoinCondition condition, boolean leftRowOnly,
-                boolean inputIsLeft) throws Exception {
+                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception {
             emitCompleteState(be, collect, otherView, condition);
         }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
@@ -134,7 +134,7 @@ public final class JoinRecordStateViews {
         @Override
         public void emitCompleteState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
                 JoinRecordStateView otherView, JoinCondition condition, boolean leftRowOnly,
-                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception {
+                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled) throws Exception {
             emitCompleteState(be, collect, otherView, condition);
         }
 
@@ -221,7 +221,7 @@ public final class JoinRecordStateViews {
         @Override
         public void emitCompleteState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
                 JoinRecordStateView otherView, JoinCondition condition, boolean leftRowOnly,
-                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception {
+                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled) throws Exception {
             emitCompleteState(be, collect, otherView, condition);
         }
 
@@ -341,7 +341,7 @@ public final class JoinRecordStateViews {
         @Override
         public void emitCompleteState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
                 JoinRecordStateView otherView, JoinCondition condition, boolean leftRowOnly,
-                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception {
+                boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled) throws Exception {
             emitCompleteState(be, collect, otherView, condition);
         }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateView.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateView.java
@@ -61,5 +61,5 @@ public interface OuterJoinRecordStateView extends JoinRecordStateView {
     /** Emit anti join state */
     void emitAntiJoinState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
         JoinRecordStateView otherView, JoinCondition condition, boolean inputRowOnly,
-        boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception;
+        boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled) throws Exception;
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateView.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateView.java
@@ -61,5 +61,5 @@ public interface OuterJoinRecordStateView extends JoinRecordStateView {
     /** Emit anti join state */
     void emitAntiJoinState(KeyedStateBackend<RowData> be, Collector<RowData> collect,
         JoinRecordStateView otherView, JoinCondition condition, boolean inputRowOnly,
-        boolean inputIsLeft) throws Exception;
+        boolean inputIsLeft, boolean isEquijoin, boolean isOuterJoin, boolean statelessNullKeysEnabled, boolean isBatchMode) throws Exception;
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
@@ -169,7 +169,7 @@ public final class OuterJoinRecordStateViews {
             }
         }
 
-        if (!isAntiJoin && StreamingPerfOptimizationUtil.isEligibleForNullEquijoinOptimization(
+        if (StreamingPerfOptimizationUtil.isEligibleForNullEquijoinOptimization(
                 isKeyAnyNulls,
                 isEquijoin,
                 false, // We are evicting state and transitioning to streaming so set batch_mode to False


### PR DESCRIPTION
Summary
---------

Issue: https://github.com/fentik/flink/issues/30

This pull request adds optimization for outer joins on a NULL key - while emitting the complete state, it evicts null records for these queries. As mentioned in https://github.com/fentik/flink/issues/30, Flink Join operators maintain
a complete set of all input data from left & right sides during a join. In the case of an outer equi join on a null key, we don't need to maintain as much state as the NULL value in the key will result in a failing join condition - in these cases, we can safely construct output rows without maintain any op state. This pull request builds this optimization for "Batch Backfill" mode - where when switching from batch to streaming (i.e. emitStateAndSwitchToStreaming), it cleans up state
for null keys -- thereby reducing operator state that is maintained. This PR also adds an execution option called
table.exec.stateless-join-on-null-key that allows you to control whether this optimization is enabled.

Test Plan
-------------
1) Execute following commands in Flink SQL: set table.exec.stateless-join-on-null-key='True'; set table.exec.batch-backfill='True';
2) Create NULL JOIN key in Postgress: update product set category_id=NULL where id=5699;
3) Execute LEFT OUTER JOIN in Flink SQL: select pc.id as category_id, p.id as product_id, product_name, category_name from product p left outer join product_category pc on p.category_id=pc.id;
4) Tail logs and make sure log line:
   "Performance Optimization - Evicting NULL record from state in outer
equijoin" is present
5) Run internal fentik regression test pipeline

See <img width="1767" alt="Screen Shot 2023-03-21 at 3 25 55 PM" src="https://user-images.githubusercontent.com/8899705/226766232-6a189ea6-b107-4f74-8f5c-05cac4576cf0.png">
where we see records get evicted from state